### PR TITLE
chore(IdlingResourceSample): bump gradle wrapper 6.5.1 → 6.8.3

### DIFF
--- a/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
## Summary

Bitrise's gradle mirrors init script (injected into `~/.gradle/init.d/` by the `install-missing-android-tools` step's "Activate Bitrise mirrors for Gradle" sub-step) uses `getDependencyResolutionManagement()`, a gradle 6.8+ API on Settings. The `IdlingResourceSample` fixture pins gradle 6.5.1, which fails the init script's Kotlin compilation:

```
bitrise-gradle-mirrors.init.gradle.kts:80
Unresolved reference: getDependencyResolutionManagement
Script compilation error.
```

This blocks every e2e that consumes this fixture — currently the [bitrise-step-android-lint #34](https://github.com/bitrise-steplib/bitrise-step-android-lint/pull/34) monorepo e2e.

## Why 6.8.3 (not 7.x / 8.x)

- ✅ Adds `getDependencyResolutionManagement()` on Settings (the API the mirrors plugin needs).
- ✅ Stays within AGP 4.0.1's officially supported gradle range (≥6.1.1).
- ❌ Gradle 7.x / 8.x would force an AGP bump (AGP 4 → 7+), `jcenter` → `mavenCentral` repo migration, `compile` → `implementation` config rename, and AndroidX migration (this fixture is still on `com.android.support`). That's a substantial migration for what's primarily an espresso idling-resource sample.

6.8.3 = last 6.8.x patch.

## Test plan

- [ ] The downstream [bitrise-step-android-lint #34](https://github.com/bitrise-steplib/bitrise-step-android-lint/pull/34) e2e (which currently has an in-repo wrapper-bump workaround) goes green after this lands.
- [ ] No other build files touched, so the existing fixture build behaviour stays identical aside from the gradle version itself.