### PR TITLE
chore: bulk-bump fixtures to gradle 6.8.3 + AGP 4.0.1 for mirror compat

### DIFF
--- a/integration/ServiceTestRuleSample/build.gradle
+++ b/integration/ServiceTestRuleSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/integration/ServiceTestRuleSample/gradle/wrapper/gradle-wrapper.properties
+++ b/integration/ServiceTestRuleSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/runner/AndroidJunitRunnerSample/build.gradle
+++ b/runner/AndroidJunitRunnerSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/runner/AndroidJunitRunnerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/runner/AndroidJunitRunnerSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/BasicSample/build.gradle
+++ b/ui/espresso/BasicSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/BasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/BasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/CustomMatcherSample/build.gradle
+++ b/ui/espresso/CustomMatcherSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/CustomMatcherSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/CustomMatcherSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/DataAdapterSample/build.gradle
+++ b/ui/espresso/DataAdapterSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/DataAdapterSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/DataAdapterSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/IntentsAdvancedSample/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/IntentsAdvancedSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IntentsAdvancedSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/IntentsBasicSample/build.gradle
+++ b/ui/espresso/IntentsBasicSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/IntentsBasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IntentsBasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/MultiProcessSample/build.gradle
+++ b/ui/espresso/MultiProcessSample/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/MultiProcessSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/MultiProcessSample/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/MultiWindowSample/build.gradle
+++ b/ui/espresso/MultiWindowSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/MultiWindowSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/MultiWindowSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/RecyclerViewSample/build.gradle
+++ b/ui/espresso/RecyclerViewSample/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/RecyclerViewSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/RecyclerViewSample/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/espresso/WebBasicSample/build.gradle
+++ b/ui/espresso/WebBasicSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ui/espresso/WebBasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/WebBasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/ui/uiautomator/BasicSample/build.gradle
+++ b/ui/uiautomator/BasicSample/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
     }
 }
 

--- a/ui/uiautomator/BasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/uiautomator/BasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/unit/BasicSample-kotlinApp/build.gradle
+++ b/unit/BasicSample-kotlinApp/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/unit/BasicSample-kotlinApp/gradle/wrapper/gradle-wrapper.properties
+++ b/unit/BasicSample-kotlinApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/unit/BasicSample/build.gradle
+++ b/unit/BasicSample/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/unit/BasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/unit/BasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/unit/BasicUnitAndroidTest/build.gradle
+++ b/unit/BasicUnitAndroidTest/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/unit/BasicUnitAndroidTest/gradle/wrapper/gradle-wrapper.properties
+++ b/unit/BasicUnitAndroidTest/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip


### PR DESCRIPTION
## Summary

Bumps every sample subproject in this repo to **gradle 6.8.3 + AGP 4.0.1** so it works with the Bitrise gradle mirrors init script (which uses `getDependencyResolutionManagement()`, a gradle 6.8+ API on `Settings`).

Before this PR, 16 subprojects pinned gradle 4.1 (one on 4.9, one on 6.5.1) and AGP 3.0.1 / 3.2.1 / 2.3.3 — any consumer e2e cloning this fixture and running gradle in those subdirs failed with:

```
bitrise-gradle-mirrors.init.gradle.kts
Unresolved reference: getDependencyResolutionManagement
Script compilation error.
```

## Diff shape

- 16 `gradle/wrapper/gradle-wrapper.properties`: `gradle-*-all.zip` → `gradle-6.8.3-all.zip`.
- 15 root `build.gradle`: `com.android.tools.build:gradle:*` → `4.0.1` (the IdlingResourceSample was already on 4.0.1).
- No source/build-config changes beyond these — `compile` / `androidTestCompile` configurations, `jcenter()`, `com.android.support` libs all left as-is (deprecated under AGP 4 but still functional; the samples keep their original "old android testing sample" character).

## Why 6.8.3 / 4.0.1

- ✅ 6.8.3 (last 6.8.x patch) adds `getDependencyResolutionManagement()` — the smallest jump that unblocks the mirror plugin.
- ✅ AGP 4.0.1 is in the supported gradle 6.8.x range (AGP 3.x maxes out at gradle 6.7).
- ❌ Jumping to gradle 7.x / 8.x or AGP 7+ would force `compile`→`implementation`, jcenter→mavenCentral, AndroidX migration per subproject — large effort with high risk for samples that aren't actively maintained.

## Supersedes

[#6](https://github.com/bitrise-io/android-testing/pull/6) (single-subproject bump for IdlingResourceSample). That PR can be closed once this one lands; IdlingResourceSample's wrapper bump is folded in here.

## Out of scope

- `unit/BasicSample-kotlinAppDetektGradle4.9` — pinned to gradle 4.9 intentionally for Detekt compat testing (per its directory name). Bumping defeats its purpose. Any future consumer running it with the mirrors plugin active would still fail; the right fix for that case is on the CLI side (mirror init script gradle-version-aware reflection guard).

## Test plan

- [ ] Downstream [bitrise-step-android-lint #34](https://github.com/bitrise-steplib/bitrise-step-android-lint/pull/34) e2e (currently has an in-step wrapper-bump workaround) goes green after this lands, and that workaround gets reverted.
- [ ] Spot-check at least one of the bulk-bumped projects builds cleanly with gradle 6.8.3 + AGP 4.0.1 (consumer e2es serve as the integration test — there's no CI on this fixture repo).